### PR TITLE
prevent prismlauncher crashing on BSD

### DIFF
--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -25,3 +25,4 @@ type="required"
 versionRange="${target_minecraft}"
 ordering="NONE"
 side="BOTH"
+

--- a/src/main/templates/fabric.mod.json
+++ b/src/main/templates/fabric.mod.json
@@ -21,3 +21,4 @@
     "minecraft": "${target_minecraft}"
   }
 }
+

--- a/src/main/templates/pack.mcmeta
+++ b/src/main/templates/pack.mcmeta
@@ -4,3 +4,4 @@
         "pack_format": ${pack_format}
     }
 }
+


### PR DESCRIPTION
added newlines at the end of template files to prevent prismlauncher from crashing on BSD when opening the mods tab or downloading the mod

`Terminating due to uncaught exception 0x15be4cd9e300 of type toml::v3::ex::parse_error`